### PR TITLE
Fix publishing setup and add auto-update workflow

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,73 @@
+name: Auto-update types from OpenAPI
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  update-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch latest OpenAPI schemas
+        run: npm run update-schemas
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code src/types/ || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push if changed
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add src/types/ openapi.yaml media-agent-openapi.yaml
+          git commit -m "chore: update types from OpenAPI spec"
+          git push
+
+      - name: Create changeset
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          cat << EOF > .changeset/auto-update-$(date +%s).md
+          ---
+          "@scope3/agentic-client": patch
+          ---
+
+          Update types from latest OpenAPI specification
+          EOF
+          git add .changeset/
+          git commit -m "chore: create changeset for type updates"
+          git push
+
+      - name: Version packages
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          npx changeset version
+          git add .
+          git commit -m "chore: version packages"
+          git push
+
+      - name: Build and publish
+        if: steps.git-check.outputs.changed == 'true'
+        run: npm run release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -38,5 +39,5 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "scope3-media-agent": "dist/media-agent-server.js"
+        "simple-media-agent": "dist/simple-media-agent-server.js"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.1",
@@ -3305,16 +3305,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6053,6 +6043,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/lint-staged/node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "TypeScript client for the Scope3 Agentic API with AdCP webhook support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "simple-media-agent": "dist/simple-media-agent-server.js"
   },
@@ -32,6 +35,14 @@
   ],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scope3data/agentic-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/scope3data/agentic-client/issues"
+  },
+  "homepage": "https://github.com/scope3data/agentic-client#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.1",
     "express": "^4.18.0",


### PR DESCRIPTION
## Summary
Fixes the changesets publishing workflow and adds automated OpenAPI schema updates with auto-publishing.

## Changes

### 1. Fixed GitHub Actions Permissions
- Updated `release.yml` to support `PAT_TOKEN` as fallback
- Fixes: "GitHub Actions is not permitted to create or approve pull requests" error
- Now works with either workflow permissions enabled OR a PAT token

### 2. Added Auto-Update Workflow
- New `.github/workflows/auto-update.yml`
- Runs daily at 2 AM UTC (cron scheduled)
- Can also be triggered manually via Actions UI
- Fully automated:
  1. Fetches latest OpenAPI schemas from docs.agentic.scope3.com
  2. Generates TypeScript types
  3. Checks if types changed
  4. If changed: commits → creates changeset → versions → builds → publishes to npm

### 3. Package Name
- Keeping `@scope3/agentic-client` (not changing to @scope3data)
- Publishing to npm.org with public access

## Testing
✅ Type-check passed
✅ Build passed  
✅ Tests passed (9/9)
✅ No TODOs or commented code
✅ Production-ready

## Setup Required

To complete the setup, you need to do **ONE** of these:

**Option A** (Recommended): Enable Actions to create PRs
- Go to: https://github.com/scope3data/agentic-client/settings/actions
- Select "Read and write permissions"
- Check "Allow GitHub Actions to create and approve pull requests"

**Option B**: Create a Personal Access Token
- Create PAT with `repo` and `workflow` scopes
- Add it as `PAT_TOKEN` secret in repo settings

Also ensure:
- ✅ `NPM_TOKEN` secret is set (for publishing to npm.org)
- ✅ npm account has access to publish `@scope3/agentic-client`

## How It Works

### Manual Changes
1. Developer creates changeset
2. Merges to main
3. Release workflow creates "Version Packages" PR
4. Merge that PR → publishes to npm.org

### Automated OpenAPI Updates
1. Daily check at 2 AM UTC (or manual trigger)
2. Fetches latest OpenAPI schemas
3. If types changed → auto-commits, versions, and publishes
4. No manual intervention needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)