### PR TITLE
fix: remove conflicting NPM_TOKEN from Trusted Publishing workflow

### DIFF
--- a/.changeset/fix-npm-trusted-publisher.md
+++ b/.changeset/fix-npm-trusted-publisher.md
@@ -1,0 +1,7 @@
+---
+"scope3": patch
+---
+
+Fix npm Trusted Publisher authentication by removing conflicting NPM_TOKEN
+
+The release workflow was failing because it had both OIDC Trusted Publishing configured (id-token: write) and the legacy NPM_TOKEN environment variable. This caused npm authentication to fail. Removed NPM_TOKEN to use only Trusted Publishing for secure, token-free npm publishing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,3 @@ jobs:
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Removes NPM_TOKEN environment variable from release workflow that was causing authentication failures
- The workflow already has `id-token: write` for Trusted Publishing (OIDC), which conflicts with legacy token authentication
- NPM_TOKEN was accidentally reintroduced in PR #21

## Root Cause
When both Trusted Publishing (`id-token: write`) and legacy token authentication (`NPM_TOKEN`) are configured, npm authentication fails with "ENEEDAUTH" error.

## Solution
Remove the `NPM_TOKEN` environment variable to use only Trusted Publishing for secure, token-free npm publishing.

## Test Plan
- [x] Build passes locally
- [x] Tests pass locally
- [ ] Verify release workflow succeeds after merge

## Related Issues
Fixes the npm publishing failure that started after PR #21 was merged.