### PR TITLE
feat: close stale auto-update PRs before creating new ones

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -38,6 +38,17 @@ jobs:
         run: |
           git diff --exit-code src/types/ outcome-agent-openapi.yaml partner-api.yaml platform-api.yaml || echo "changed=true" >> $GITHUB_OUTPUT
 
+      - name: Close existing auto-update PRs
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          # Find and close all existing auto-update PRs
+          gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("auto-update-openapi-")) | .number' | while read pr_number; do
+            echo "Closing PR #$pr_number"
+            gh pr close $pr_number --comment "Closing this PR as a new auto-update is available." --delete-branch
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
       - name: Create Pull Request
         if: steps.git-check.outputs.changed == 'true'
         run: |


### PR DESCRIPTION
## Summary
This PR improves the auto-update OpenAPI workflow to prevent accumulation of stale PRs by automatically closing old auto-update PRs before creating a new one.

## Changes
- Added "Close existing auto-update PRs" step to the workflow
- Workflow now finds all open PRs with branch names starting with `auto-update-openapi-`
- Closes each old PR with a comment explaining why
- Deletes the associated branches to keep the repo clean

## Why
Currently there are 8+ open auto-update PRs that are essentially duplicates. This change ensures only the most recent auto-update PR remains open at any time.

## Testing
- ✅ Lint passes
- ✅ Build passes  
- ✅ All tests pass (84 passing)

The workflow will automatically clean up existing stale PRs the next time it runs and detects changes.