### PR TITLE
chore: remove patch changeset to unblock 2.0.0 publish

### DIFF
--- a/.changeset/fix-npm-publish.md
+++ b/.changeset/fix-npm-publish.md
@@ -1,5 +1,0 @@
----
-"scope3": patch
----
-
-Fix npm Trusted Publishing by adding registry-url to setup-node in release workflow


### PR DESCRIPTION
Removes the patch changeset that was blocking the release workflow from publishing scope3@2.0.0. With a changeset present, the action creates a version PR instead of publishing.

Needs admin merge — will fail changeset CI check (by design).