### PR TITLE
chore(ci): use scope3-wizard github app for release changeset prs + merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,18 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.SCOPE3_WIZARD_APP_ID }}
+          private-key: ${{ secrets.SCOPE3_WIZARD_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       # setup-node used directly: internal action doesn't support registry-url
       - name: Setup Node.js
@@ -43,4 +50,4 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Currently, version updates are opened autonomously by @nastassiafulconis' personal access token. This PR moves it to be our GitHub app, Scope3 Wizard!