### PR TITLE
Add conductor setup script for workspace initialization

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,32 @@
 {
+  "name": "Scope3 Agentic Client",
+  "description": "TypeScript client for Scope3 Agentic API using MCP protocol",
+  "version": "0.1.0",
+  "setup": {
+    "commands": [
+      {
+        "command": "npm install",
+        "description": "Install dependencies and set up git hooks (Husky)"
+      }
+    ]
+  },
   "scripts": {
+    "dev": {
+      "command": "npm run build -- --watch",
+      "description": "Build in watch mode for development"
+    },
+    "test": {
+      "command": "npm test",
+      "description": "Run all tests"
+    },
+    "type-check": {
+      "command": "npm run type-check",
+      "description": "Check TypeScript types without building"
+    },
+    "update-schemas": {
+      "command": "npm run update-schemas",
+      "description": "Download latest OpenAPI spec and regenerate TypeScript types"
+    },
     "setup": "./scripts/conductor-setup.sh"
   }
 }

--- a/conductor.json
+++ b/conductor.json
@@ -1,31 +1,5 @@
 {
-  "name": "Scope3 Agentic Client",
-  "description": "TypeScript client for Scope3 Agentic API using MCP protocol",
-  "version": "0.1.0",
-  "setup": {
-    "commands": [
-      {
-        "command": "npm install",
-        "description": "Install dependencies and set up git hooks (Husky)"
-      }
-    ]
-  },
   "scripts": {
-    "dev": {
-      "command": "npm run build -- --watch",
-      "description": "Build in watch mode for development"
-    },
-    "test": {
-      "command": "npm test",
-      "description": "Run all tests"
-    },
-    "type-check": {
-      "command": "npm run type-check",
-      "description": "Check TypeScript types without building"
-    },
-    "update-schemas": {
-      "command": "npm run update-schemas",
-      "description": "Download latest OpenAPI spec and regenerate TypeScript types"
-    }
+    "setup": "./scripts/conductor-setup.sh"
   }
 }

--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+echo "Setting up Scope3 Agentic Client workspace..."
+
+# Find the git root directory (the actual repository root, not the workspace)
+# Conductor provides CONDUCTOR_ROOT_PATH for the original repo location in newer versions
+# Fall back to detecting from PWD or git for backward compatibility
+if [ -n "$CONDUCTOR_ROOT_PATH" ]; then
+  GIT_ROOT="$CONDUCTOR_ROOT_PATH"
+elif [[ "$PWD" == *"/.conductor/"* ]]; then
+  GIT_ROOT=$(echo "$PWD" | sed 's|\(.*\)/\.conductor/.*|\1|')
+else
+  GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$GIT_ROOT" ]; then
+    echo "ERROR: Not inside a git repository"
+    exit 1
+  fi
+fi
+
+echo "Using repository root: $GIT_ROOT"
+
+# Copy .env file from root repository
+echo "Copying .env from root repository..."
+if [ -f "$GIT_ROOT/.env" ]; then
+  cp "$GIT_ROOT/.env" .env
+  echo ".env file copied successfully"
+elif [ -f ".env.example" ]; then
+  echo "WARNING: .env file not found at $GIT_ROOT/.env"
+  echo "Copying .env.example as a starting point..."
+  cp .env.example .env
+  echo "Please update .env with your actual values"
+else
+  echo "WARNING: No .env file found. Create one based on .env.example"
+fi
+
+# Export environment variables for validation
+if [ -f ".env" ]; then
+  echo "Loading environment variables..."
+  set -a
+  source .env
+  set +a
+fi
+
+# Validate critical environment variables
+MISSING_VARS=()
+
+if [ -z "$SCOPE3_API_KEY" ]; then
+  MISSING_VARS+=("SCOPE3_API_KEY")
+fi
+
+if [ ${#MISSING_VARS[@]} -gt 0 ]; then
+  echo ""
+  echo "WARNING: Missing environment variables:"
+  for var in "${MISSING_VARS[@]}"; do
+    echo "  - $var"
+  done
+  echo ""
+  echo "Please update .env with your actual values before running the client."
+fi
+
+# Install dependencies
+echo "Installing dependencies..."
+npm install
+
+echo ""
+echo "Workspace setup complete!"
+echo ""
+echo "Next steps:"
+echo "  - Ensure SCOPE3_API_KEY is set in .env"
+echo "  - Run 'npm run build' to compile TypeScript"
+echo "  - Run 'npm test' to run tests"


### PR DESCRIPTION
## Summary
- Add `scripts/conductor-setup.sh` that handles .env copying from the root repo, environment variable validation, and `npm install`
- Simplify `conductor.json` to match the pattern used in scope3 and agentic-api repos (`scripts.setup` pointing to the shell script)

## Test plan
- [ ] Run `bash scripts/conductor-setup.sh` in a fresh workspace and verify it copies .env and installs deps
- [ ] Verify Conductor picks up the setup script from conductor.json