### PR TITLE
chore: add weekly Dependabot checks for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scope3data/platform"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scope3data/platform"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly checks for **npm** and **github-actions** ecosystems
- Sets `@scope3data/platform` as the reviewer team for Dependabot PRs

Closes AM-1078

## Test plan
- [ ] Verify YAML is valid and PR merges cleanly
- [ ] After merge, confirm Dependabot starts opening PRs on the next weekly cycle (check repo Settings > Code security and analysis if needed)