### PR TITLE
fix(ci): use client-id for create-github-app-token v3

### DIFF
--- a/.github/workflows/regenerate-schemas.yml
+++ b/.github/workflows/regenerate-schemas.yml
@@ -17,7 +17,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.SCOPE3_WIZARD_APP_ID }}
+          client-id: ${{ vars.SCOPE3_WIZARD_CLIENT_ID }}
           private-key: ${{ secrets.SCOPE3_WIZARD_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.SCOPE3_WIZARD_APP_ID }}
+          client-id: ${{ vars.SCOPE3_WIZARD_CLIENT_ID }}
           private-key: ${{ secrets.SCOPE3_WIZARD_APP_PRIVATE_KEY }}
 
       - name: Checkout code


### PR DESCRIPTION
## Summary

The recent Dependabot bump of `actions/create-github-app-token` from v2 to v3 (#139) broke the release and regenerate-schemas workflows. v3 renamed the `app-id` input to `client-id` and requires the GitHub App's Client ID instead of the numeric App ID.

- Updates `release.yml` and `regenerate-schemas.yml` to use `client-id` with the new `SCOPE3_WIZARD_CLIENT_ID` org variable.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Merge to `main` and confirm the release workflow triggers successfully