### PR TITLE
fix(ci): replace private actions with inline equivalents, add failure notifications

### DIFF
--- a/.github/actions/slack-post/action.yml
+++ b/.github/actions/slack-post/action.yml
@@ -1,0 +1,73 @@
+name: Post Slack Message
+description: Post a Block Kit message to a Slack channel via chat.postMessage
+
+inputs:
+  channel:
+    description: Slack channel to post to (e.g. '#agentic-service-alerts')
+    required: true
+  header:
+    description: Header text for the message (also used as fallback text)
+    required: true
+  content:
+    description: JSON array of Block Kit blocks for the message body
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Post to Slack
+      shell: bash
+      env:
+        SLACK_CHANNEL: ${{ inputs.channel }}
+        SLACK_HEADER: ${{ inputs.header }}
+        SLACK_CONTENT: ${{ inputs.content }}
+        GITHUB_REPO: ${{ github.repository }}
+        GITHUB_SERVER: ${{ github.server_url }}
+        GITHUB_RUN: ${{ github.run_id }}
+      run: |
+        if [ -z "$SLACK_TOKEN" ]; then
+          echo "::error::SLACK_TOKEN environment variable is not set"
+          exit 1
+        fi
+
+        if ! echo "$SLACK_CONTENT" | jq -e 'type == "array"' > /dev/null 2>&1; then
+          echo "::error::content input must be a valid JSON array"
+          exit 1
+        fi
+
+        TIMESTAMP=$(date +%s)
+        TIMESTAMP_FMT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+        PAYLOAD=$(jq -n \
+          --arg channel "$SLACK_CHANNEL" \
+          --arg header "$SLACK_HEADER" \
+          --arg repo "$GITHUB_REPO" \
+          --arg server "$GITHUB_SERVER" \
+          --arg run_id "$GITHUB_RUN" \
+          --argjson content "$SLACK_CONTENT" \
+          --argjson ts "$TIMESTAMP" \
+          --arg ts_fmt "$TIMESTAMP_FMT" \
+          '{
+            channel: $channel,
+            text: $header,
+            blocks: (
+              [
+                {type: "header", text: {type: "plain_text", text: $header}},
+                {type: "context", elements: [{type: "mrkdwn", text: "<\($server)/\($repo)|\($repo)> | <\($server)/\($repo)/actions/runs/\($run_id)|Run #\($run_id)>"}]}
+              ]
+              + $content
+              + [
+                {type: "context", elements: [{type: "mrkdwn", text: "Posted at <!date^\($ts)^{date_num} {time_secs}|\($ts_fmt)>"}]}
+              ]
+            )
+          }')
+
+        RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+          -H "Authorization: Bearer $SLACK_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD")
+
+        if [ "$(echo "$RESPONSE" | jq -r '.ok')" != "true" ]; then
+          echo "::error::Slack API error: $(echo "$RESPONSE" | jq -r '.error')"
+          exit 1
+        fi

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -55,43 +55,27 @@ jobs:
 
       - name: Alert on drift
         if: steps.drift.outputs.exit_code == '1'
+        uses: ./.github/actions/slack-post
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_NOTIF_BOT_TOKEN }}
-        run: |
-          TIMESTAMP=$(date +%s)
-          TIMESTAMP_FMT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          PAYLOAD=$(jq -n \
-            --arg channel "#agentic-service-alerts" \
-            --arg header "SDK API Drift Detected" \
-            --arg repo "${{ github.repository }}" \
-            --arg server "${{ github.server_url }}" \
-            --arg run_id "${{ github.run_id }}" \
-            --arg total "${{ steps.parse.outputs.total }}" \
-            --arg skill_missing "${{ steps.parse.outputs.skill_missing }}" \
-            --arg skill_extra "${{ steps.parse.outputs.skill_extra }}" \
-            --arg sdk_missing "${{ steps.parse.outputs.sdk_missing }}" \
-            --arg sdk_extra "${{ steps.parse.outputs.sdk_extra }}" \
-            --argjson ts "$TIMESTAMP" \
-            --arg ts_fmt "$TIMESTAMP_FMT" \
-            '{
-              channel: $channel,
-              text: $header,
-              blocks: [
-                {type: "header", text: {type: "plain_text", text: $header}},
-                {type: "context", elements: [{type: "mrkdwn", text: "<\($server)/\($repo)|\($repo)> | <\($server)/\($repo)/actions/runs/\($run_id)|Run #\($run_id)>"}]},
-                {type: "section", text: {type: "mrkdwn", text: ("*\($total) endpoint(s) out of sync*\n\n*skill.md vs spec:*\n• Missing from skill.md: \($skill_missing)\n• Extra in skill.md: \($skill_extra)\n\n*SDK vs spec:*\n• Missing from SDK: \($sdk_missing)\n• Extra in SDK: \($sdk_extra)")}},
-                {type: "section", text: {type: "mrkdwn", text: "<\($server)/\($repo)/actions/runs/\($run_id)|View full report>"}},
-                {type: "context", elements: [{type: "mrkdwn", text: "Posted at <!date^\($ts)^{date_num} {time_secs}|\($ts_fmt)>"}]}
-              ]
-            }')
-          RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $SLACK_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD")
-          if [ "$(echo "$RESPONSE" | jq -r '.ok')" != "true" ]; then
-            echo "Slack API error: $(echo "$RESPONSE" | jq -r '.error')"
-            exit 1
-          fi
+        with:
+          channel: '#agentic-service-alerts'
+          header: 'SDK API Drift Detected'
+          content: |
+            [
+              {"type": "section", "text": {"type": "mrkdwn", "text": "*${{ steps.parse.outputs.total }} endpoint(s) out of sync*\n\n*skill.md vs spec:*\n• Missing from skill.md: ${{ steps.parse.outputs.skill_missing }}\n• Extra in skill.md: ${{ steps.parse.outputs.skill_extra }}\n\n*SDK vs spec:*\n• Missing from SDK: ${{ steps.parse.outputs.sdk_missing }}\n• Extra in SDK: ${{ steps.parse.outputs.sdk_extra }}"}},
+              {"type": "section", "text": {"type": "mrkdwn", "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View full report>"}}
+            ]
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/slack-post
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_NOTIF_BOT_TOKEN }}
+        with:
+          channel: '#agentic-service-alerts'
+          header: 'API Drift Detection Failed'
+          content: '[{"type": "section", "text": {"type": "mrkdwn", "text": "The drift detection workflow failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"}}]'
 
   regenerate:
     name: Regenerate Schemas

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -14,7 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: scope3data/actions/node/install@node/install/v1
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund --ignore-scripts
 
       - name: Run drift detection
         id: drift
@@ -51,27 +57,41 @@ jobs:
         if: steps.drift.outputs.exit_code == '1'
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_NOTIF_BOT_TOKEN }}
-        uses: scope3data/actions/slack/post@slack/post/v2
-        with:
-          channel: '#agentic-service-alerts'
-          header: 'SDK API Drift Detected'
-          content: |
-            [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*${{ steps.parse.outputs.total }} endpoint(s) out of sync*\n\n*skill.md vs spec:*\n• Missing from skill.md: ${{ steps.parse.outputs.skill_missing }}\n• Extra in skill.md: ${{ steps.parse.outputs.skill_extra }}\n\n*SDK vs spec:*\n• Missing from SDK: ${{ steps.parse.outputs.sdk_missing }}\n• Extra in SDK: ${{ steps.parse.outputs.sdk_extra }}"
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View full report>"
-                }
-              }
-            ]
+        run: |
+          TIMESTAMP=$(date +%s)
+          TIMESTAMP_FMT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          PAYLOAD=$(jq -n \
+            --arg channel "#agentic-service-alerts" \
+            --arg header "SDK API Drift Detected" \
+            --arg repo "${{ github.repository }}" \
+            --arg server "${{ github.server_url }}" \
+            --arg run_id "${{ github.run_id }}" \
+            --arg total "${{ steps.parse.outputs.total }}" \
+            --arg skill_missing "${{ steps.parse.outputs.skill_missing }}" \
+            --arg skill_extra "${{ steps.parse.outputs.skill_extra }}" \
+            --arg sdk_missing "${{ steps.parse.outputs.sdk_missing }}" \
+            --arg sdk_extra "${{ steps.parse.outputs.sdk_extra }}" \
+            --argjson ts "$TIMESTAMP" \
+            --arg ts_fmt "$TIMESTAMP_FMT" \
+            '{
+              channel: $channel,
+              text: $header,
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: $header}},
+                {type: "context", elements: [{type: "mrkdwn", text: "<\($server)/\($repo)|\($repo)> | <\($server)/\($repo)/actions/runs/\($run_id)|Run #\($run_id)>"}]},
+                {type: "section", text: {type: "mrkdwn", text: ("*\($total) endpoint(s) out of sync*\n\n*skill.md vs spec:*\n• Missing from skill.md: \($skill_missing)\n• Extra in skill.md: \($skill_extra)\n\n*SDK vs spec:*\n• Missing from SDK: \($sdk_missing)\n• Extra in SDK: \($sdk_extra)")}},
+                {type: "section", text: {type: "mrkdwn", text: "<\($server)/\($repo)/actions/runs/\($run_id)|View full report>"}},
+                {type: "context", elements: [{type: "mrkdwn", text: "Posted at <!date^\($ts)^{date_num} {time_secs}|\($ts_fmt)>"}]}
+              ]
+            }')
+          RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          if [ "$(echo "$RESPONSE" | jq -r '.ok')" != "true" ]; then
+            echo "Slack API error: $(echo "$RESPONSE" | jq -r '.error')"
+            exit 1
+          fi
 
   regenerate:
     name: Regenerate Schemas

--- a/.github/workflows/regenerate-schemas.yml
+++ b/.github/workflows/regenerate-schemas.yml
@@ -87,36 +87,24 @@ jobs:
 
       - name: Notify Slack
         if: steps.create-pr.outputs.pr_url
+        uses: ./.github/actions/slack-post
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_NOTIF_BOT_TOKEN }}
-        run: |
-          TIMESTAMP=$(date +%s)
-          TIMESTAMP_FMT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          PAYLOAD=$(jq -n \
-            --arg channel "#agentic-service-alerts" \
-            --arg header "SDK Schemas Regenerated" \
-            --arg repo "${{ github.repository }}" \
-            --arg server "${{ github.server_url }}" \
-            --arg run_id "${{ github.run_id }}" \
-            --arg pr_url "${{ steps.create-pr.outputs.pr_url }}" \
-            --argjson ts "$TIMESTAMP" \
-            --arg ts_fmt "$TIMESTAMP_FMT" \
-            '{
-              channel: $channel,
-              text: $header,
-              blocks: [
-                {type: "header", text: {type: "plain_text", text: $header}},
-                {type: "context", elements: [{type: "mrkdwn", text: "<\($server)/\($repo)|\($repo)> | <\($server)/\($repo)/actions/runs/\($run_id)|Run #\($run_id)>"}]},
-                {type: "section", text: {type: "mrkdwn", text: "A PR has been created to update Zod schemas from the latest OpenAPI specification."}},
-                {type: "section", text: {type: "mrkdwn", text: "<\($pr_url)|View Pull Request>"}},
-                {type: "context", elements: [{type: "mrkdwn", text: "Posted at <!date^\($ts)^{date_num} {time_secs}|\($ts_fmt)>"}]}
-              ]
-            }')
-          RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $SLACK_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD")
-          if [ "$(echo "$RESPONSE" | jq -r '.ok')" != "true" ]; then
-            echo "Slack API error: $(echo "$RESPONSE" | jq -r '.error')"
-            exit 1
-          fi
+        with:
+          channel: '#agentic-service-alerts'
+          header: 'SDK Schemas Regenerated'
+          content: |
+            [
+              {"type": "section", "text": {"type": "mrkdwn", "text": "A PR has been created to update Zod schemas from the latest OpenAPI specification."}},
+              {"type": "section", "text": {"type": "mrkdwn", "text": "<${{ steps.create-pr.outputs.pr_url }}|View Pull Request>"}}
+            ]
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/slack-post
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_NOTIF_BOT_TOKEN }}
+        with:
+          channel: '#agentic-service-alerts'
+          header: 'Schema Regeneration Failed'
+          content: '[{"type": "section", "text": {"type": "mrkdwn", "text": "The schema regeneration workflow failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"}}]'

--- a/.github/workflows/regenerate-schemas.yml
+++ b/.github/workflows/regenerate-schemas.yml
@@ -24,7 +24,13 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: scope3data/actions/node/install@node/install/v1
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund --ignore-scripts
 
       - name: Regenerate schemas
         run: npm run generate-schemas
@@ -83,24 +89,34 @@ jobs:
         if: steps.create-pr.outputs.pr_url
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_NOTIF_BOT_TOKEN }}
-        uses: scope3data/actions/slack/post@slack/post/v2
-        with:
-          channel: '#agentic-service-alerts'
-          header: 'SDK Schemas Regenerated'
-          content: |
-            [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "A PR has been created to update Zod schemas from the latest OpenAPI specification."
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "<${{ steps.create-pr.outputs.pr_url }}|View Pull Request>"
-                }
-              }
-            ]
+        run: |
+          TIMESTAMP=$(date +%s)
+          TIMESTAMP_FMT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          PAYLOAD=$(jq -n \
+            --arg channel "#agentic-service-alerts" \
+            --arg header "SDK Schemas Regenerated" \
+            --arg repo "${{ github.repository }}" \
+            --arg server "${{ github.server_url }}" \
+            --arg run_id "${{ github.run_id }}" \
+            --arg pr_url "${{ steps.create-pr.outputs.pr_url }}" \
+            --argjson ts "$TIMESTAMP" \
+            --arg ts_fmt "$TIMESTAMP_FMT" \
+            '{
+              channel: $channel,
+              text: $header,
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: $header}},
+                {type: "context", elements: [{type: "mrkdwn", text: "<\($server)/\($repo)|\($repo)> | <\($server)/\($repo)/actions/runs/\($run_id)|Run #\($run_id)>"}]},
+                {type: "section", text: {type: "mrkdwn", text: "A PR has been created to update Zod schemas from the latest OpenAPI specification."}},
+                {type: "section", text: {type: "mrkdwn", text: "<\($pr_url)|View Pull Request>"}},
+                {type: "context", elements: [{type: "mrkdwn", text: "Posted at <!date^\($ts)^{date_num} {time_secs}|\($ts_fmt)>"}]}
+              ]
+            }')
+          RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          if [ "$(echo "$RESPONSE" | jq -r '.ok')" != "true" ]; then
+            echo "Slack API error: $(echo "$RESPONSE" | jq -r '.error')"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,13 @@ jobs:
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/slack-post
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_NOTIF_BOT_TOKEN }}
+        with:
+          channel: '#agentic-service-alerts'
+          header: 'Release Failed'
+          content: '[{"type": "section", "text": {"type": "mrkdwn", "text": "The release workflow failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"}}]'


### PR DESCRIPTION
## Summary

- **Root cause**: `scope3data/actions` is a private repo, but `agentic-client` is public — GitHub blocks public repos from using actions defined in private repos, causing "Unable to resolve action" failures in drift-detection and regenerate-schemas workflows
- **Replaced `scope3data/actions/node/install`** with `actions/setup-node@v6` + `npm ci` in both workflows
- **Replaced `scope3data/actions/slack/post`** with a new local composite action at `.github/actions/slack-post/action.yml` that wraps the Slack `chat.postMessage` API
- **Added failure notifications** (`if: failure()`) to drift-detection, regenerate-schemas, and release workflows — all post to `#agentic-service-alerts`

### Composite action details

The `slack-post` action takes `channel`, `header`, and `content` (Block Kit JSON array) as inputs, with `SLACK_TOKEN` passed via env. It automatically prepends a header block and repo context, appends a timestamp footer, validates the content is a JSON array, and checks the Slack API response for errors. All inputs are passed through env vars to avoid shell injection.

## Test plan

- [ ] Trigger `drift-detection` via `workflow_dispatch` — should resolve actions and run successfully
- [ ] If drift is detected, verify Slack notification posts to `#agentic-service-alerts` with correct formatting
- [ ] Trigger `regenerate-schemas` via `workflow_dispatch` to verify node setup and Slack notification
- [ ] Verify failure notifications work (temporarily inject `exit 1` before the failure handler, or check next natural failure)