### PR TITLE
fix(ci): use GitHub App token for changeset release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,15 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate GitHub App token
         id: app-token
@@ -28,7 +30,10 @@ jobs:
           private-key: ${{ secrets.SCOPE3_WIZARD_APP_PRIVATE_KEY }}
 
       - name: Configure git for app token
-        run: git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}"
+        run: |
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}"
+          git config user.name "scope3-wizard[bot]"
+          git config user.email "${{ vars.SCOPE3_WIZARD_APP_ID }}+scope3-wizard[bot]@users.noreply.github.com"
 
       # setup-node used directly: internal action doesn't support registry-url
       - name: Setup Node.js
@@ -48,6 +53,8 @@ jobs:
           version: npm run version
           commit: 'chore: version packages'
           title: 'chore: version packages'
+          setupGitUser: false
+          github-token: ${{ steps.app-token.outputs.token }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Firecrawl scrape artifacts
+.firecrawl/


### PR DESCRIPTION
## Summary

- The release workflow's `changesets/action` was failing with a 403 on push because `actions/checkout` persists an `http.extraheader` with the read-only default token, which overrides all other git credentials (URL-embedded and `.netrc`)
- Adds `persist-credentials: false` to checkout, passes the Scope3 Wizard app token as both `github-token` input and `GITHUB_TOKEN` env var, configures git user as `scope3-wizard[bot]`, and grants `contents: write` + `pull-requests: write` permissions
- After merging, PR #125 (authored by `nastassiafulconis`) should be closed so the action creates a fresh one under the app identity

## Test plan
- [ ] Merge to main and verify the Release workflow passes
- [ ] Confirm `changeset-release/main` branch is pushed successfully
- [ ] Confirm a new version PR is created by `scope3-wizard[bot]`
- [ ] Close stale PR #125