### PR TITLE
fix(ci): require new changeset per PR, emit one from schema regen

### DIFF
--- a/.changeset/schema-regen-changeset-check.md
+++ b/.changeset/schema-regen-changeset-check.md
@@ -1,0 +1,5 @@
+---
+'scope3': patch
+---
+
+Ensure schema regeneration PRs include a changeset and require new changesets in every non-release PR

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -15,28 +15,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Check for changeset
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Skip changeset check for release PRs created by changesets/action
-          if [[ "${{ github.head_ref }}" == changeset-release/* ]] || [[ "${{ github.event.pull_request.title }}" == "chore: version packages" ]]; then
-            echo "⏭️  Skipping changeset check for release PR"
+          if [[ "$HEAD_REF" == changeset-release/* ]] || [[ "$PR_TITLE" == "chore: version packages" ]]; then
+            echo "Skipping changeset check for release PR"
             exit 0
           fi
 
-          if [ -z "$(ls -A .changeset/*.md 2>/dev/null | grep -v README)" ]; then
-            echo "❌ No changeset found. Please add a changeset by running 'npm run changeset'"
+          NEW_CHANGESETS=$(git diff --name-only --diff-filter=A "$BASE_SHA...HEAD" -- '.changeset/*.md' | grep -v 'README\.md' || true)
+
+          if [ -z "$NEW_CHANGESETS" ]; then
+            echo "No new changeset found in this PR."
             echo ""
-            echo "Changesets help track version changes and generate changelogs."
-            echo "Run 'npm run changeset' and follow the prompts to create one."
+            echo "Every PR must add a changeset file to .changeset/."
+            echo "Run 'npm run changeset' to create one describing your change."
+            echo "If no version bump is needed, run 'npx changeset --empty'."
             exit 1
-          else
-            echo "✅ Changeset found"
           fi
+
+          echo "New changeset(s) added in this PR:"
+          echo "$NEW_CHANGESETS"

--- a/.github/workflows/regenerate-schemas.yml
+++ b/.github/workflows/regenerate-schemas.yml
@@ -60,13 +60,24 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          BRANCH="chore/regenerate-schemas-$(date +%Y%m%d-%H%M%S)"
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          BRANCH="chore/regenerate-schemas-${TIMESTAMP}"
+          CHANGESET_FILE=".changeset/regenerate-schemas-${TIMESTAMP}.md"
 
           git config user.name "scope3-wizard[bot]"
           git config user.email "${{ vars.SCOPE3_WIZARD_APP_ID }}+scope3-wizard[bot]@users.noreply.github.com"
 
           git checkout -b "$BRANCH"
-          git add src/schemas/
+
+          cat > "$CHANGESET_FILE" <<'EOF'
+          ---
+          'scope3': minor
+          ---
+
+          Regenerate Zod schemas from the latest OpenAPI specification
+          EOF
+
+          git add src/schemas/ "$CHANGESET_FILE"
           git commit -m "chore: regenerate schemas from OpenAPI spec"
           git push origin "$BRANCH"
 


### PR DESCRIPTION
## Summary

- **Changeset check was too permissive.** The previous check failed only when `.changeset/` was empty, so any pending unreleased changeset let every PR pass. That's how PRs #153 and #155 merged schema updates without adding changesets — and why the "Version Packages" PR (#152) doesn't reflect any of the schema work.
- **Tightened the check** to diff the PR against its base and fail unless a *new* `.changeset/*.md` file is added. Escape hatch for opt-outs is `npx changeset --empty`.
- **Schema regeneration workflow now emits a changeset** (`minor` bump) alongside `src/schemas/` so future auto-regen PRs bump the version.

## Test plan

- [x] Both workflow YAMLs parse via `yaml.safe_load`
- [x] Detection logic verified locally: `git diff --diff-filter=A BASE...HEAD -- '.changeset/*.md'` correctly lists the new file on this branch
- [x] `npm run type-check` passes
- [ ] Changeset check job on this PR passes (confirming the new rule catches/allows itself correctly)