### PR TITLE
fix: address review feedback from #170

### DIFF
--- a/.changeset/pr-170-review-feedback.md
+++ b/.changeset/pr-170-review-feedback.md
@@ -1,0 +1,5 @@
+---
+'scope3': patch
+---
+
+Remove placeholder test stubs for deleted resources, reject storefront persona at runtime, remove unsafe index signatures from campaign input types, add response validation to campaign create/update, and type campaign sub-endpoint responses.

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -114,7 +114,8 @@ function postProcessSchemas(filePath: string) {
     });
   });
 
-  // Add explicit type annotation to avoid TS7056 (inferred type too large for declaration files)
+  // The schemas bag uses Record<string, z.ZodTypeAny> to avoid TS7056
+  // (inferred type too large for declaration files).
   content = content.replace(
     'export const schemas = {',
     'export const schemas: Record<string, z.ZodTypeAny> = {'

--- a/src/__tests__/cli/commands/storefront.test.ts
+++ b/src/__tests__/cli/commands/storefront.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -53,6 +53,12 @@ describe('Scope3Client', () => {
       expect(() => new Scope3Client({ apiKey: 'test-key' } as any)).toThrow('persona is required');
     });
 
+    it('should reject storefront persona', () => {
+      expect(() => new Scope3Client({ apiKey: 'test-key', persona: 'storefront' })).toThrow(
+        'Scope3Client only supports the buyer persona'
+      );
+    });
+
     it('should default to v2 version', () => {
       const client = new Scope3Client({ apiKey: 'test-key', persona: 'buyer' });
       expect(client.version).toBe('v2');

--- a/src/__tests__/resources/agents.test.ts
+++ b/src/__tests__/resources/agents.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/bundles.test.ts
+++ b/src/__tests__/resources/bundles.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/conversion-events.test.ts
+++ b/src/__tests__/resources/conversion-events.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/creative-sets.test.ts
+++ b/src/__tests__/resources/creative-sets.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/inventory-sources.test.ts
+++ b/src/__tests__/resources/inventory-sources.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/notifications.test.ts
+++ b/src/__tests__/resources/notifications.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/products.test.ts
+++ b/src/__tests__/resources/products.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/readiness.test.ts
+++ b/src/__tests__/resources/readiness.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/sales-agents.test.ts
+++ b/src/__tests__/resources/sales-agents.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/signals.test.ts
+++ b/src/__tests__/resources/signals.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/__tests__/resources/storefront.test.ts
+++ b/src/__tests__/resources/storefront.test.ts
@@ -1,3 +1,0 @@
-describe('removed', () => {
-  it.todo('resource removed in v3');
-});

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -40,9 +40,9 @@ configCommand
     }
 
     // Validate persona
-    if (key === 'persona' && !['buyer', 'storefront'].includes(value)) {
+    if (key === 'persona' && value !== 'buyer') {
       console.error(chalk.red(`Invalid persona: ${value}`));
-      console.error('Valid personas: buyer, storefront');
+      console.error('Valid personas: buyer');
       process.exit(1);
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -43,7 +43,7 @@ program
   .option('--base-url <url>', 'Custom API base URL')
   .option('--format <format>', 'Output format: json, table, or yaml (default: table)')
   .option('--debug', 'Enable debug mode')
-  .option('--persona <persona>', 'API persona: buyer or storefront (default: buyer)');
+  .option('--persona <persona>', 'API persona (default: buyer)');
 
 program.hook('preAction', (_thisCommand, actionCommand) => {
   const skipCommands = ['login', 'logout', 'config', 'commands'];

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,7 +63,10 @@ export class Scope3Client {
       throw new Error('apiKey is required');
     }
     if (!config.persona) {
-      throw new Error('persona is required (buyer or storefront)');
+      throw new Error('persona is required');
+    }
+    if (config.persona !== 'buyer') {
+      throw new Error('Scope3Client only supports the buyer persona');
     }
 
     this.version = config.version ?? 'v2';

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,11 @@ export type {
   CreateCampaignInput,
   UpdateCampaignInput,
   ListCampaignsParams,
+  AutoSelectProductsResult,
+  CampaignProductEntry,
+  CampaignProductsResult,
+  CampaignMediaBuyStatus,
+  MediaBuyStatusValue,
   // Test Cohorts
   TestCohort,
   CreateTestCohortInput,

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ export type {
   CreateCampaignInput,
   UpdateCampaignInput,
   ListCampaignsParams,
+  RefinementItem,
   AutoSelectProductsResult,
   CampaignProductEntry,
   CampaignProductsResult,

--- a/src/resources/campaigns.ts
+++ b/src/resources/campaigns.ts
@@ -10,6 +10,9 @@ import type {
   ListCampaignsParams,
   PaginatedApiResponse,
   ApiResponse,
+  AutoSelectProductsResult,
+  CampaignProductsResult,
+  CampaignMediaBuyStatus,
 } from '../types';
 import { campaignSchemas } from '../schemas/registry';
 import { shouldValidateResponse, validateResponse } from '../validation';
@@ -60,7 +63,11 @@ export class CampaignsResource {
    * @returns Created campaign
    */
   async create(data: CreateCampaignInput): Promise<ApiResponse<Campaign>> {
-    return this.adapter.request<ApiResponse<Campaign>>('POST', '/campaigns', data);
+    const result = await this.adapter.request<ApiResponse<Campaign>>('POST', '/campaigns', data);
+    if (shouldValidateResponse(this.adapter.validate)) {
+      result.data = validateResponse(campaignSchemas.response, result.data) as unknown as Campaign;
+    }
+    return result;
   }
 
   /**
@@ -70,11 +77,15 @@ export class CampaignsResource {
    * @returns Updated campaign
    */
   async update(id: string, data: UpdateCampaignInput): Promise<ApiResponse<Campaign>> {
-    return this.adapter.request<ApiResponse<Campaign>>(
+    const result = await this.adapter.request<ApiResponse<Campaign>>(
       'PUT',
       `/campaigns/${validateResourceId(id)}`,
       data
     );
+    if (shouldValidateResponse(this.adapter.validate)) {
+      result.data = validateResponse(campaignSchemas.response, result.data) as unknown as Campaign;
+    }
+    return result;
   }
 
   /**
@@ -88,14 +99,18 @@ export class CampaignsResource {
   /**
    * Auto-select products for a campaign
    * @param id Campaign ID
-   * @param data Optional configuration for product selection
-   * @returns Auto-selection result
+   * @param data Optional refinement and configuration for product selection
+   * @returns Auto-selection result with selected products
    */
   async autoSelectProducts(
     id: string,
-    data?: Record<string, unknown>
-  ): Promise<ApiResponse<Record<string, unknown>>> {
-    return this.adapter.request<ApiResponse<Record<string, unknown>>>(
+    data?: {
+      refine?: Array<Record<string, unknown>>;
+      maxProducts?: number;
+      minBudgetPerProduct?: number;
+    }
+  ): Promise<ApiResponse<AutoSelectProductsResult>> {
+    return this.adapter.request<ApiResponse<AutoSelectProductsResult>>(
       'POST',
       `/campaigns/${validateResourceId(id)}/auto-select-products`,
       data
@@ -105,10 +120,10 @@ export class CampaignsResource {
   /**
    * Get media buy status for a campaign
    * @param id Campaign ID
-   * @returns Media buy status
+   * @returns Media buy statuses
    */
-  async getMediaBuyStatus(id: string): Promise<ApiResponse<Record<string, unknown>>> {
-    return this.adapter.request<ApiResponse<Record<string, unknown>>>(
+  async getMediaBuyStatus(id: string): Promise<ApiResponse<CampaignMediaBuyStatus>> {
+    return this.adapter.request<ApiResponse<CampaignMediaBuyStatus>>(
       'GET',
       `/campaigns/${validateResourceId(id)}/media-buy-status`
     );
@@ -117,10 +132,10 @@ export class CampaignsResource {
   /**
    * Get products associated with a campaign
    * @param id Campaign ID
-   * @returns Campaign products
+   * @returns Campaign products with summary
    */
-  async getProducts(id: string): Promise<ApiResponse<Record<string, unknown>>> {
-    return this.adapter.request<ApiResponse<Record<string, unknown>>>(
+  async getProducts(id: string): Promise<ApiResponse<CampaignProductsResult>> {
+    return this.adapter.request<ApiResponse<CampaignProductsResult>>(
       'GET',
       `/campaigns/${validateResourceId(id)}/products`
     );

--- a/src/resources/campaigns.ts
+++ b/src/resources/campaigns.ts
@@ -53,7 +53,7 @@ export class CampaignsResource {
       `/campaigns/${validateResourceId(id)}`
     );
     if (shouldValidateResponse(this.adapter.validate)) {
-      result.data = validateResponse(campaignSchemas.response, result.data) as unknown as Campaign;
+      result.data = validateResponse(campaignSchemas.response, result.data);
     }
     return result;
   }
@@ -66,7 +66,7 @@ export class CampaignsResource {
   async create(data: CreateCampaignInput): Promise<ApiResponse<Campaign>> {
     const result = await this.adapter.request<ApiResponse<Campaign>>('POST', '/campaigns', data);
     if (shouldValidateResponse(this.adapter.validate)) {
-      result.data = validateResponse(campaignSchemas.response, result.data) as unknown as Campaign;
+      result.data = validateResponse(campaignSchemas.response, result.data);
     }
     return result;
   }
@@ -84,7 +84,7 @@ export class CampaignsResource {
       data
     );
     if (shouldValidateResponse(this.adapter.validate)) {
-      result.data = validateResponse(campaignSchemas.response, result.data) as unknown as Campaign;
+      result.data = validateResponse(campaignSchemas.response, result.data);
     }
     return result;
   }

--- a/src/resources/campaigns.ts
+++ b/src/resources/campaigns.ts
@@ -13,6 +13,7 @@ import type {
   AutoSelectProductsResult,
   CampaignProductsResult,
   CampaignMediaBuyStatus,
+  RefinementItem,
 } from '../types';
 import { campaignSchemas } from '../schemas/registry';
 import { shouldValidateResponse, validateResponse } from '../validation';
@@ -105,7 +106,7 @@ export class CampaignsResource {
   async autoSelectProducts(
     id: string,
     data?: {
-      refine?: Array<Record<string, unknown>>;
+      refine?: RefinementItem[];
       maxProducts?: number;
       minBudgetPerProduct?: number;
     }

--- a/src/schemas/registry.ts
+++ b/src/schemas/registry.ts
@@ -1,15 +1,27 @@
+import { type ZodType } from 'zod';
 import { schemas } from './buyer';
+import type {
+  Campaign,
+  CreateCampaignInput,
+  UpdateCampaignInput,
+  CreateAdvertiserInput,
+  UpdateAdvertiserInput,
+} from '../types';
+
+function typed<T>(schema: unknown): ZodType<T> {
+  return schema as ZodType<T>;
+}
 
 export const advertiserSchemas = {
-  createInput: schemas.CreateAdvertiserBody,
-  updateInput: schemas.UpdateAdvertiserBody,
+  createInput: typed<CreateAdvertiserInput>(schemas.CreateAdvertiserBody),
+  updateInput: typed<UpdateAdvertiserInput>(schemas.UpdateAdvertiserBody),
 };
 
 export const campaignSchemas = {
-  createInput: schemas.CreateCampaignBody,
-  updateInput: schemas.UpdateCampaignBody,
+  createInput: typed<CreateCampaignInput>(schemas.CreateCampaignBody),
+  updateInput: typed<UpdateCampaignInput>(schemas.UpdateCampaignBody),
   executeInput: schemas.ExecuteCampaignBody,
-  response: schemas.Campaign,
+  response: typed<Campaign>(schemas.Campaign),
   listResponse: schemas.CampaignListResponse,
   statusChangeResponse: schemas.CampaignStatusChangeResponse,
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -265,6 +265,10 @@ export interface ListCampaignsParams extends PaginationParams {
   status?: CampaignStatus;
 }
 
+export type RefinementItem =
+  | { scope: 'request'; ask: string }
+  | { scope: 'product'; id: string; action: 'include' | 'omit' | 'moreLikeThis'; ask?: string };
+
 export interface AutoSelectProductsResult {
   campaignId: string;
   discoveryId: string;
@@ -275,7 +279,17 @@ export interface AutoSelectProductsResult {
     groupId: string;
     groupName: string;
     cpm?: number;
+    budget: number;
+    pricingOptionId?: string;
   }>;
+  budgetContext: {
+    campaignBudget: number;
+    totalAllocated: number;
+    remainingBudget: number;
+    currency: string;
+  };
+  productCount: number;
+  previouslySelectedCount?: number;
 }
 
 export interface CampaignProductEntry {
@@ -289,6 +303,9 @@ export interface CampaignProductEntry {
   budget?: number;
   pricingOptionId?: string;
   pricingModel?: string;
+  selectedAt: string;
+  searchContext?: { id: string; brief: string };
+  mediaBuys: Array<{ MediaBuyId: string; Status: string; name: string }>;
 }
 
 export interface CampaignProductsResult {
@@ -317,16 +334,24 @@ export type MediaBuyStatusValue =
   | 'ACTIVE'
   | 'PAUSED'
   | 'COMPLETED'
-  | 'CANCELED';
+  | 'CANCELED'
+  | 'FAILED'
+  | 'REJECTED'
+  | 'ARCHIVED';
 
 export interface CampaignMediaBuyStatus {
-  mediaBuys: Array<{
-    MediaBuyId: string;
-    name: string;
-    Status: string;
-    startTime?: string;
-    endTime?: string;
+  campaign_id: string;
+  media_buys: Array<{
+    media_buy_id: string;
+    adcp_media_buy_id: string;
+    internal_status: string;
+    adcp_status: string | null;
+    previous_internal_status: string;
+    previous_adcp_status: string | null;
+    updated: boolean;
   }>;
+  agents_queried: number;
+  errors: Array<{ media_buy_id: string; error: string }>;
 }
 
 // ============================================================================

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -247,7 +247,6 @@ export interface CreateCampaignInput {
   brief?: string;
   constraints?: CampaignConstraints;
   performanceConfig?: PerformanceConfig;
-  [key: string]: unknown;
 }
 
 export interface UpdateCampaignInput {
@@ -258,13 +257,76 @@ export interface UpdateCampaignInput {
   brief?: string;
   constraints?: CampaignConstraints;
   performanceConfig?: PerformanceConfig;
-  [key: string]: unknown;
 }
 
 export interface ListCampaignsParams extends PaginationParams {
   advertiserId?: string;
   type?: CampaignType;
   status?: CampaignStatus;
+}
+
+export interface AutoSelectProductsResult {
+  campaignId: string;
+  discoveryId: string;
+  selectedProducts: Array<{
+    productId: string;
+    name: string;
+    salesAgentId: string;
+    groupId: string;
+    groupName: string;
+    cpm?: number;
+  }>;
+}
+
+export interface CampaignProductEntry {
+  productId: string;
+  productName?: string;
+  salesAgentId: string;
+  salesAgentName?: string;
+  publisherDomain?: string;
+  publisherName?: string;
+  bidPrice?: number;
+  budget?: number;
+  pricingOptionId?: string;
+  pricingModel?: string;
+}
+
+export interface CampaignProductsResult {
+  campaignId: string;
+  discoveryId: string | null;
+  products: CampaignProductEntry[];
+  searchContexts: Array<{
+    id: string;
+    brief: string;
+    channels: string[];
+    countries: string[];
+    createdAt: string;
+    productCount: number;
+  }>;
+  summary: {
+    totalProducts: number;
+    productsOnMediaBuys: number;
+    productsPending: number;
+  };
+}
+
+export type MediaBuyStatusValue =
+  | 'DRAFT'
+  | 'PENDING_APPROVAL'
+  | 'INPUT_REQUIRED'
+  | 'ACTIVE'
+  | 'PAUSED'
+  | 'COMPLETED'
+  | 'CANCELED';
+
+export interface CampaignMediaBuyStatus {
+  mediaBuys: Array<{
+    MediaBuyId: string;
+    name: string;
+    Status: string;
+    startTime?: string;
+    endTime?: string;
+  }>;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Addresses retroactive review comments from #170:

- Delete placeholder test files for removed resources (the `describe('removed')` stubs were noise with temporal references)
- Reject `storefront` persona in `Scope3Client` constructor at runtime — prevents silent misconfiguration
- Remove `[key: string]: unknown` index signatures from `CreateCampaignInput` and `UpdateCampaignInput` to restore type safety
- Add response validation via `campaignSchemas.response` to `create` and `update` methods (matching `get`)
- Type `autoSelectProducts`, `getMediaBuyStatus`, `getProducts` return values using shapes from the OpenAPI spec instead of `Record<string, unknown>`

## Test plan

- [x] `tsc --noEmit` passes
- [x] 27 test suites, 418 tests pass
- [x] Prettier and ESLint clean
- [ ] CI passes